### PR TITLE
Avoid double import of jQuery when ember-cli has already included it.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,10 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    vendorFiles: {
-      // opt out via vendorFiles to ensure no jquery doubling occurs
-      'jquery.js': null
-    }
+    // Add options here
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -6,7 +6,11 @@ module.exports = {
     this._super.included.apply(this, arguments);
     let app = this._findHost();
     let optionalFeatures = app.project.findAddonByName("@ember/optional-features");
-    app.import('vendor/jquery/jquery.js', { prepend: true });
+
+    if (!app.vendorFiles || !app.vendorFiles['jquery.js']) {
+      app.import('vendor/jquery/jquery.js', { prepend: true });
+    }
+
     if (optionalFeatures && optionalFeatures.isFeatureEnabled('jquery-integration')) {
       app.project.ui.writeDeprecateLine('You have disabled the `jquery-integration` optional feature. You now have to delete `@ember/jquery` from your package.json');
     }


### PR DESCRIPTION
Fixes #3