### PR TITLE
Fix logic around warning instructing to remove @ember/jquery.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
       app.import('vendor/jquery/jquery.js', { prepend: true });
     }
 
-    if (optionalFeatures && optionalFeatures.isFeatureEnabled('jquery-integration')) {
+    if (optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')) {
       app.project.ui.writeDeprecateLine('You have disabled the `jquery-integration` optional feature. You now have to delete `@ember/jquery` from your package.json');
     }
   },


### PR DESCRIPTION
When the optional feature is `true` `@ember/jquery` _should_ be used, jQuery integration is only disabled when the value is `false`...

Fixes emberjs/ember.js#16723