### PR TITLE
Add jQuery shim as part of RFC386

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,12 +11,15 @@ module.exports = {
       app.import('vendor/jquery/jquery.js', { prepend: true });
     }
 
+    app.import('vendor/shims/jquery.js');
+
     if (optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')) {
       app.project.ui.writeDeprecateLine('You have disabled the `jquery-integration` optional feature. You now have to delete `@ember/jquery` from your package.json');
     }
   },
 
-  treeForVendor: function() {
+  treeForVendor: function(tree) {
+    const BroccoliMergeTrees = require('broccoli-merge-trees');
     const Funnel = require('broccoli-funnel');
     const resolve = require('resolve');
     const path = require('path');
@@ -35,6 +38,6 @@ module.exports = {
       files: ['jquery.js'],
     });
 
-    return jquery;
+    return new BroccoliMergeTrees([jquery, tree]);
   },
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^3.0.2",
     "ember-cli-babel": "^7.1.2",
     "jquery": "^3.3.1",
     "resolve": "^1.9.0"

--- a/tests/unit/import-jquery-test.js
+++ b/tests/unit/import-jquery-test.js
@@ -1,0 +1,9 @@
+import jQuery from 'jquery';
+import { module, test } from 'qunit';
+
+module('Unit | import-jquery', function() {
+
+  test('it works', function(assert) {
+    assert.equal(jQuery, window.jQuery, 'jQuery shim return global jQuery');
+  });
+});

--- a/vendor/shims/jquery.js
+++ b/vendor/shims/jquery.js
@@ -1,0 +1,12 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return {
+      'default': self['jquery'],
+      __esModule: true,
+    };
+  }
+
+  define('jquery', [], vendorModule);
+})();


### PR DESCRIPTION
Makes `import jQuery from 'jquery';` work, without transpiling it to `Ember.$`.