### PR TITLE
Configurable shim module format - AMD or ES2015

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,6 @@ module.exports = {
       app.import('vendor/jquery/jquery.js', { prepend: true });
     }
 
-    app.import('vendor/shims/jquery.js');
-
     let checker = new VersionChecker(this);
     let ember = checker.forEmber();
 
@@ -27,6 +25,14 @@ module.exports = {
 
     if (optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')) {
       app.project.ui.writeDeprecateLine('You have disabled the `jquery-integration` optional feature. You now have to delete `@ember/jquery` from your package.json');
+    }
+
+    const appConfig = app.project.config(app.env)['ember-jquery'] || {};
+
+    if (appConfig.moduleFormat === 'amd') {
+      app.import('vendor/shims/jquery-amd.js');
+    } else {
+      app.import('vendor/shims/jquery.js');
     }
   },
 

--- a/vendor/shims/jquery-amd.js
+++ b/vendor/shims/jquery-amd.js
@@ -1,0 +1,8 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+    return self['jQuery']
+  }
+
+  define('jquery', [], vendorModule);
+})();


### PR DESCRIPTION
This proof-of-concept PR suggests a solution to https://github.com/emberjs/ember-jquery/issues/98. It allows downstream apps to choose the module format for the ember-query shim added in https://github.com/emberjs/ember-jquery/pull/33.

This solves an issue for AMD-dependent systems like one of ours, which uses [ember-cli/loader](https://github.com/ember-cli/loader.js) to set up a module alias. This was breaking down when receiving the shim in ES2015 format.
