### PR TITLE
Add directions to import and use jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ ember install @ember/optional-features
 ember feature:enable jquery-integration
 ``` 
 
+Usage
+------------------------------------------------------------------------------
+
+import jQuery from 'jquery'
+const element = jQuery('#special');
+
 Contributing
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
jQuery isn't exported from `ember-jquery` as one might suspect from this
package's name. I've added some directions to alleviate this
confusion.

Fixes #128