### PR TITLE
Now suppressing component-dollar rather than raising a deprecation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@ ember-jquery
 ==============================================================================
 
 Ember has been historically coupled to jQuery. As part of 
-[RFC294](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md#introduce-emberjquery-package)
-jQuery has been made optional and this addon will explicitly add the jQuery integration functionality.
+[RFC294](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md#introduce-emberjquery-package),
+jQuery has been made optional. 
+
+This addon makes jQuery available in an Ember project. It also provides the mechanism that implements jQuery 
+integration when that feature is enabled. 
 
 
 Compatibility
@@ -21,7 +24,7 @@ Installation
 ember install @ember/jquery
 ```
 
-You should also explicitly tell Ember to enable its jQuery integration:
+If you also wish to enable Ember's jQuery integration, you must do so explicitly:
 
 ```bash
 ember install @ember/optional-features

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -42,6 +42,22 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-lts-3.8',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.8.0'
+            }
+          }
+        },
+        {
+          name: 'ember-lts-3.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.12.0'
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {

--- a/index.js
+++ b/index.js
@@ -10,24 +10,23 @@ module.exports = {
     const VersionChecker = require('ember-cli-version-checker');
 
     let app = this._findHost();
-    let optionalFeatures = app.project.findAddonByName("@ember/optional-features");
-
+    
     if (!app.vendorFiles || !app.vendorFiles['jquery.js']) {
       app.import('vendor/jquery/jquery.js', { prepend: true });
     }
 
     app.import('vendor/shims/jquery.js');
 
+    let optionalFeatures = app.project.findAddonByName("@ember/optional-features");
+    let integrationTurnedOff = optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration');
+
     let checker = new VersionChecker(this);
     let ember = checker.forEmber();
-
-    if (ember.gte(EMBER_VERSION_WITH_JQUERY_DEPRECATION)) {
+    
+    if (ember.gte(EMBER_VERSION_WITH_JQUERY_DEPRECATION) && !integrationTurnedOff) {
       app.import('vendor/jquery/component.dollar.js');
     }
 
-    if (optionalFeatures && !optionalFeatures.isFeatureEnabled('jquery-integration')) {
-      app.project.ui.writeDeprecateLine('You have disabled the `jquery-integration` optional feature. You now have to delete `@ember/jquery` from your package.json');
-    }
   },
 
   treeForVendor: function(tree) {


### PR DESCRIPTION
Using a `this.$()` with explicit jquery-integration: false now invokes the code in emberjs proper. However, that emberjs code throws an assertion rather than displaying a deprecation when it detects the feature is disabled. 

I'm of two minds whether this is appropriate. If it was an assertion because the flag indicated that jQuery would be absent so the call would fail anyway, it was only appropriate while the flag was closely coupled to the presence/absence of the package. If it interprets the explicit flag as saying, "As far as Ember is concerned, jQuery is no longer here," it might be quite appropriate.

I'm perfectly happy to leave this to wiser heads to sort out and implement what they recommend. One possibility is to provide an alternate implementation of component.dollar.js in this case that still applies the deprecation, but, knowing the jquery is present, doesn't resort to the assertion.