### PR TITLE
Add missing deprecation message for `this.$()`

### DIFF
--- a/tests/integration/components/component-dot-dollar-test.js
+++ b/tests/integration/components/component-dot-dollar-test.js
@@ -19,21 +19,17 @@ module('Integration | Component | component-dot-dollar', function(hooks) {
     this.setJQueryElement = ($) => this.$element = $;
   });
 
-  test('it implements Component.$()', function(assert) {
-    return assert.noDeprecations(async () => {
-      await render(hbs`{{jquery-component id="jq" setJQueryElement=setJQueryElement}}`);
+  test('it implements Component.$()', async function(assert) {
+    await render(hbs`{{jquery-component id="jq" setJQueryElement=setJQueryElement}}`);
 
-      assert.ok(this.$element, 'Component.$() is available');
-      assert.ok(this.$element instanceof jQuery, 'Component.$() returns a jQuery object');
-      assert.equal(this.$element.get(0), this.element.querySelector('#jq'), 'Component.$() is a jQuery wrapper around Component.element');
-    });
+    assert.ok(this.$element, 'Component.$() is available');
+    assert.ok(this.$element instanceof jQuery, 'Component.$() returns a jQuery object');
+    assert.equal(this.$element.get(0), this.element.querySelector('#jq'), 'Component.$() is a jQuery wrapper around Component.element');
   });
 
-  test('it implements Component.$(selector)',  function(assert) {
-    return assert.noDeprecations(async () => {
-      await render(hbs`{{#jquery-component id="jq" selector="div" setJQueryElement=setJQueryElement}}<div id="child"/>{{/jquery-component}}`);
+  test('it implements Component.$(selector)', async function(assert) {
+    await render(hbs`{{#jquery-component id="jq" selector="div" setJQueryElement=setJQueryElement}}<div id="child"/>{{/jquery-component}}`);
 
-      assert.equal(this.$element.get(0), this.element.querySelector('#child'), 'Component.$(selector) is a jQuery object of the child elements matching selector');
-    });
+    assert.equal(this.$element.get(0), this.element.querySelector('#child'), 'Component.$(selector) is a jQuery object of the child elements matching selector');
   });
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,35 +1,7 @@
-import QUnit from 'qunit';
-import { registerDeprecationHandler } from '@ember/debug';
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
-
-let deprecations;
-
-registerDeprecationHandler((message, options, next) => {
-  // in case a deprecation is issued before a test is started
-  if (!deprecations) {
-    deprecations = [];
-  }
-
-  deprecations.push(message);
-  next(message, options);
-});
-
-QUnit.testStart(function() {
-  deprecations = [];
-});
-
-QUnit.assert.noDeprecations = async function(callback) {
-  let originalDeprecations = deprecations;
-  deprecations = [];
-
-  await callback();
-  this.deepEqual(deprecations, [], 'Expected no deprecations during test.');
-
-  deprecations = originalDeprecations;
-};
 
 setApplication(Application.create(config.APP));
 

--- a/vendor/jquery/component.dollar.js
+++ b/vendor/jquery/component.dollar.js
@@ -1,4 +1,4 @@
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 
 (function() {
   Ember.Component.reopen({
@@ -6,6 +6,16 @@ import { assert } from '@ember/debug';
       assert(
         "You cannot access this.$() on a component with `tagName: ''` specified.",
         this.tagName !== ''
+      );
+
+      deprecate(
+        'Using this.$() in a component has been deprecated, consider using this.element',
+        false,
+        {
+          id: 'ember-views.curly-components.jquery-element',
+          until: '4.0.0',
+          url: 'https://emberjs.com/deprecations/v3.x#toc_jquery-apis',
+        }
       );
 
       if (this.element) {


### PR DESCRIPTION
see https://github.com/emberjs/ember.js/blob/v3.13.0/packages/%40ember/-internals/views/lib/mixins/view_support.js#L444-L452

As discussed on Discord, this should still show a deprecation warning, even when provided by `@ember/jquery`. The reason for this is that disabling the `jquery-integration` feature removes this API from the component class, even if this addon is used, and disabling the feature is required to move to Ember Octane.