### PR TITLE
Drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "release-it-lerna-changelog": "^1.0.3"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": "10.* || 12.* || >= 14.*"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
... since the Node.js team is no longer maintaining that release either.

This should unblock most of the dependency upgrade PRs.

/cc @rwjblue 