### PR TITLE
Avoid triggering Component reopen deprecation

### DIFF
--- a/vendor/jquery/component.dollar.js
+++ b/vendor/jquery/component.dollar.js
@@ -1,8 +1,14 @@
 import { assert, deprecate } from '@ember/debug';
+import EmberObject from '@ember/object';
 import Component from '@ember/component';
 
 (function() {
-  Component.reopen({
+  /*
+   * This non-standard use of `reopen` and `call` allows the component
+   * base class to be reopened without triggering the
+   * ember.component.reopen deprecation in Ember itself.
+   */
+  EmberObject.reopen.call(Component, {
     $(sel) {
       assert(
         "You cannot access this.$() on a component with `tagName: ''` specified.",


### PR DESCRIPTION
`Ember.Component.reopen` is deprecated with the id `ember.component.reopen` to be removed in Ember 4.0. Here, use a clever invocation to avoid the Ember deprecation.

Both these APIs are deprecated targeting 4.0 anyway, so this deprecation doesn't need to exist after `Component.reopen` is removed.

The avoidance of the deprecation is demonstrated by a green CI suite at https://github.com/mixonic/ember-cli-deprecation-workflow/pull/125 which would fail (with an exception of an unhandled deprecation) if the reopen deprecation were still triggered.

cc @chancancode @simonihmig 