### PR TITLE
Include `Ember.Component.prototype.$` deprecation regardless of Ember version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const EMBER_VERSION_WITH_JQUERY_DEPRECATION = '3.9.0-alpha.1';
-
 module.exports = {
   name: require('./package').name,
   included() {
     this._super.included.apply(this, arguments);
-
-    const VersionChecker = require('ember-cli-version-checker');
 
     let app = this._findHost();
 
@@ -24,13 +20,7 @@ module.exports = {
       optionalFeatures &&
       !optionalFeatures.isFeatureEnabled('jquery-integration');
 
-    let checker = new VersionChecker(this);
-    let ember = checker.forEmber();
-
-    if (
-      ember.gte(EMBER_VERSION_WITH_JQUERY_DEPRECATION) &&
-      !integrationTurnedOff
-    ) {
+    if (!integrationTurnedOff) {
       app.import('vendor/jquery/component.dollar.js');
     }
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "broccoli-funnel": "^3.0.6",
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-version-checker": "^3.1.3",
     "jquery": "^3.5.0",
     "resolve": "^1.15.1"
   },


### PR DESCRIPTION
This removes the check for Ember version, and always adds the `Ember.Component.reopen` to ensure `this.$` within a component issues a deprecation.

Note: this does **not** remove support for any Ember versions, it does however make the deprecations consistent regardless of Ember version.
